### PR TITLE
Add organism from OBI

### DIFF
--- a/src/main/resources/obi.iris
+++ b/src/main/resources/obi.iris
@@ -1,2 +1,3 @@
 +D(http://purl.obolibrary.org/obo/BFO_0000015):http://purl.obolibrary.org/obo/OBI_0000070 assay
 +(http://purl.obolibrary.org/obo/IAO_0000030):http://purl.obolibrary.org/obo/OBI_0000272 protocol
++(http://purl.obolibrary.org/obo/BFO_0000040):http://purl.obolibrary.org/obo/OBI_0100026 organism


### PR DESCRIPTION
Subclassing BFO material entity. Organism is one of the terms in NANoREG
database schema.