### PR TITLE
Add size from pato

### DIFF
--- a/src/main/resources/go.iris
+++ b/src/main/resources/go.iris
@@ -1,0 +1,1 @@
++(http://purl.obolibrary.org/obo/OBI_0000070):http://purl.obolibrary.org/obo/GO_0009293 transduction

--- a/src/main/resources/go.props
+++ b/src/main/resources/go.props
@@ -1,0 +1,3 @@
+owl=http://purl.obolibrary.org/obo/go.owl
+iris=go.iris
+slimmed=http://purl.enanomapper.org/onto/external/go-slim.owl

--- a/src/main/resources/pato.iris
+++ b/src/main/resources/pato.iris
@@ -7,3 +7,4 @@
 +D(http://purl.obolibrary.org/obo/BFO_0000019):http://purl.obolibrary.org/obo/PATO_0000161 rate
 +D(http://purl.obolibrary.org/obo/BFO_0000019):http://purl.obolibrary.org/obo/PATO_0001536 solubility
 +D(http://purl.obolibrary.org/obo/BFO_0000019):http://purl.obolibrary.org/obo/PATO_0000117 size
++(http://purl.obolibrary.org/obo/BFO_0000019):http://purl.obolibrary.org/obo/PATO_0000011 age


### PR DESCRIPTION
Subclass of BFO quality. Necessary for NANoREG mappings. https://github.com/enanomapper/ontologies/issues/25